### PR TITLE
fix: build.py sequential mode

### DIFF
--- a/bindings/python/build.py
+++ b/bindings/python/build.py
@@ -345,8 +345,8 @@ if __name__ == "__main__":
     # Compile all the targets
     ################################################################################
     if args.sequential:
-        for args in settings["targets"].items():
-            compile_target(*args, WHEELS_FOLDER, settings)
+        for args_compile in settings["targets"].items():
+            compile_target(*args_compile, WHEELS_FOLDER, settings)
     else:
         with mp.Pool(mp.cpu_count()) as pool:
             list(pool.imap(


### PR DESCRIPTION
Hi,

just ran into a bug when using the `--sequential` flag in the build script.
Essentially, it overwrites the CLI-args with something else (the content of `settings["targets"].items()` and fails later on when trying to access the CLI-args in line [484](https://github.com/redst4r/ensmallen/blob/649e8b5d26410dc4ee5c78e835a9b422e461dd69/bindings/python/build.py#L484).

Simply fixed by renaming.

PS: Awesome graph library!